### PR TITLE
fix: resolve AttributeError in tasks module settings

### DIFF
--- a/modules/tasks.py
+++ b/modules/tasks.py
@@ -1074,7 +1074,7 @@ class TasksModule:
         console.print(Panel("⚙️ CONFIGURAÇÕES", style="cyan"))
         
         console.print("\n[cyan]Informações da conta:[/cyan]")
-        console.print(f"Token API: {'*' * 20}...{Config.get('TODOIST_API_TOKEN', '')[-4:]}")
+        console.print(f"Token API: {'*' * 20}...{(Config.TODOIST_API_TOKEN or '')[-4:]}")
         
         console.print("\n[cyan]Estatísticas de uso:[/cyan]")
         try:


### PR DESCRIPTION
## Summary
- Fix AttributeError when accessing tasks module settings
- Replace non-existent `Config.get()` method with direct attribute access `Config.TODOIST_API_TOKEN`

## Test plan
- [x] Test tasks module loads without errors
- [x] Verify settings screen displays properly without crashes
- [x] Confirm Todoist token masking works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)