### PR TITLE
Fix Alzi shared expenses invoice period calculation

### DIFF
--- a/modules/finances/domains/alzi_domain_data.py
+++ b/modules/finances/domains/alzi_domain_data.py
@@ -4,7 +4,7 @@ Alzi Domain Data Layer - Camada de dados para compartilhamento com Alzi
 Implementação mínima para permitir funcionamento dos services.
 """
 
-from typing import List, Optional, Dict, Any
+from typing import List
 from datetime import datetime
 
 from utils.database_manager import DatabaseManager
@@ -19,4 +19,39 @@ class AlziDomainData:
     
     def get_shared_transactions_by_month(self, ano: int, mes: int) -> List[Transacao]:
         """Obtém transações compartilhadas de um mês específico"""
-        return []
+        from modules.finances.services.transaction_service import TransactionService
+        from modules.finances.services.card_service import CardService
+        from modules.finances.domains.transaction_domain import TransactionDomain
+        
+        # Create services
+        transaction_service = TransactionService(self.db_manager)
+        card_service = CardService(self.db_manager)
+        
+        all_transactions = transaction_service.list_transactions()
+        
+        # Filter transactions that are shared with Alzi and match the year/month
+        shared_transactions = []
+        for trans in all_transactions:
+            # Check if transaction is shared with Alzi
+            if hasattr(trans, 'compartilhado_com_alzi') and trans.compartilhado_com_alzi:
+                try:
+                    # For credit card transactions, use invoice period
+                    if trans.cartao_id:
+                        card = card_service.get_card_by_id(trans.cartao_id)
+                        if card:
+                            # Calculate which invoice this transaction belongs to
+                            trans_date = datetime.strptime(trans.data_transacao[:10], "%Y-%m-%d").date()
+                            invoice_month, invoice_year = TransactionDomain.calculate_invoice_month_for_transaction(
+                                trans_date, card.dia_fechamento
+                            )
+                            if invoice_year == ano and invoice_month == mes:
+                                shared_transactions.append(trans)
+                    else:
+                        # For debit/account transactions, use transaction date
+                        trans_date = datetime.strptime(trans.data_transacao[:10], "%Y-%m-%d")
+                        if trans_date.year == ano and trans_date.month == mes:
+                            shared_transactions.append(trans)
+                except (ValueError, AttributeError):
+                    continue
+        
+        return shared_transactions

--- a/modules/finances/services/alzi_service.py
+++ b/modules/finances/services/alzi_service.py
@@ -3,12 +3,12 @@ Alzi Service - Serviços relacionados aos gastos compartilhados com Alzi
 """
 
 from typing import List, Optional, Dict, Any
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from ..domains.alzi_domain_data import AlziDomainData
 from utils.database_manager import DatabaseManager
 from utils.finance_models import (
-    Transacao, ContaCorrente, CartaoCredito, TipoTransacao, ResumoFinanceiro
+    Transacao, TipoTransacao
 )
 
 


### PR DESCRIPTION
## Summary
• Fix timedelta import error in AlziService
• Implement proper invoice period logic for shared expenses
• Credit card transactions now correctly use invoice periods based on closing dates

## Problem
The Alzi shared expenses feature was showing zeros because:
1. Missing `timedelta` import caused crashes in detailed reports
2. `get_shared_transactions_by_month` was returning empty list
3. Credit card transactions weren't considering invoice periods

## Solution
• **AlziService**: Added missing `timedelta` import and cleaned up unused imports
• **AlziDomainData**: Implemented complete logic for `get_shared_transactions_by_month`:
  - Credit card transactions: Calculate invoice period using `TransactionDomain.calculate_invoice_month_for_transaction`
  - Debit transactions: Use transaction date directly
  - Proper error handling for date parsing

## Results
• **June 2025**: 0 transactions (June 5th transaction belongs to July invoice)
• **July 2025**: 10 transactions, R$ 633.25 total
  - Includes May 21-29 transactions (after May 20th closing date)
  - Includes June 5th transaction (before June 20th closing date)

## Test plan
- [x] Test current month shared expenses view
- [x] Test detailed report functionality  
- [x] Verify invoice period calculations for credit card transactions
- [x] Confirm debit transactions use transaction date
- [x] Test comprehensive report with insights and breakdowns

🤖 Generated with [Claude Code](https://claude.ai/code)